### PR TITLE
pefile raises the wrong heuristic

### DIFF
--- a/pe_file/pe_file.py
+++ b/pe_file/pe_file.py
@@ -669,7 +669,7 @@ class PEFile(ServiceBase):
             if e.value != "DOS Header magic not found.":
                 res_load_failed = ResultSection(f"WARNING: this file looks like a PE but failed "
                                                 f"loading inside PE file. [{e.value}]")
-                res_load_failed.set_heuristic(6)
+                res_load_failed.set_heuristic(7)
                 self.file_res.add_section(res_load_failed)
             else:
                 self.log.debug("DOS Header magic not found. This indicates that the file submitted is not a PE File.")


### PR DESCRIPTION
From my understanding if the pe fails to load then it shouldn't raise a heuristic indicating there's a signed certificate, It's an invalid file. Unless there's something I don't know. Example. https://malware-pb.cyber.gc.ca/submission/detail/2kCxlTG1TTZfoA7MHSFK91 