### PR TITLE
RT_ICON supplementary files

### DIFF
--- a/pe_file/icon_extractor.py
+++ b/pe_file/icon_extractor.py
@@ -1,0 +1,57 @@
+import struct
+from io import BytesIO
+from PIL import Image
+
+
+GRPICONDIRENTRY_format = ('GRPICONDIRENTRY',
+        ('B,Width', 'B,Height','B,ColorCount','B,Reserved',
+        'H,Planes','H,BitCount','I,BytesInRes','H,ID'))
+GRPICONDIR_format = ('GRPICONDIR',
+    ('H,Reserved', 'H,Type','H,Count'))
+
+def get_icon(pe_file, icon_rsrcs, idx):
+    
+    # print(f' {icon_rsrcs.id} -- {len(icon_rsrcs.directory.entries)} -- {idx}')
+    icon_id = icon_rsrcs.directory.entries[idx-1]
+    icon_entry = icon_id.directory.entries[0]
+
+    data_rva = icon_entry.data.struct.OffsetToData
+    size = icon_entry.data.struct.Size
+    data = pe_file.get_memory_mapped_image()[data_rva:data_rva+size]
+    return data
+
+
+
+def export_raw(pe_file, icon_rsrcs, entries, index = None):
+    if index is not None:
+        entries = entries[index:index+1]
+
+    ico = struct.pack('<HHH', 0, 1, len(entries))
+    data_offset = None
+    data = []
+    info = []
+    for grp_icon in entries:
+        if data_offset is None:
+            data_offset = len(ico) + ((grp_icon.sizeof()+2) * len(entries))
+
+        nfo = grp_icon.__pack__()[:-2] + struct.pack('<L', data_offset)			
+        info.append( nfo )
+
+        raw_data = get_icon(pe_file, icon_rsrcs, grp_icon.ID)
+        if not raw_data: continue
+
+        data.append( raw_data )
+        data_offset += len(raw_data)
+
+    raw = ico + b''.join(info) + b''.join(data)
+    return raw
+
+def icon_export(pe_file, icon_rsrcs, entries, index = None):
+    if icon_rsrcs is None:
+        return None
+
+    raw = export_raw(pe_file, icon_rsrcs, entries, index)
+    return Image.open(BytesIO(raw))
+
+
+

--- a/pe_file/icon_extractor.py
+++ b/pe_file/icon_extractor.py
@@ -32,7 +32,7 @@ def get_icon_group(pe_file: pefile.PE, data_entry : pefile.Structure) -> list:
 
     return None
 
-def get_icon(pe_file, icon_rsrcs, idx):
+def get_icon(pe_file: pefile.PE, icon_rsrcs: pefile.ResourceDirEntryData, idx: int) -> bytearray:
     icon_id = icon_rsrcs.directory.entries[idx-1]
     icon_entry = icon_id.directory.entries[0]
 
@@ -42,9 +42,9 @@ def get_icon(pe_file, icon_rsrcs, idx):
     return data
 
 
-def icon_export_raw(pe_file, icon_rsrcs, entries, index = None):
-    if index is not None:
-        entries = entries[index:index+1]
+def icon_export_raw(pe_file: pefile.PE, icon_rsrcs: pefile.ResourceDirEntryData, entries: list, idx: int=None) -> bytes:
+    if idx is not None:
+        entries = entries[idx:idx+1]
 
     ico = struct.pack('<HHH', 0, 1, len(entries))
     data_offset = None
@@ -66,11 +66,11 @@ def icon_export_raw(pe_file, icon_rsrcs, entries, index = None):
     raw = ico + b''.join(info) + b''.join(data)
     return raw
 
-def icon_export(pe_file, icon_rsrcs, entries, index = None):
+def icon_export(pe_file: pefile.PE, icon_rsrcs: pefile.ResourceDirEntryData, entries: list, idx: int=None) -> Image.Image:
     if icon_rsrcs is None:
         return None
 
-    raw = icon_export_raw(pe_file, icon_rsrcs, entries, index)
+    raw = icon_export_raw(pe_file, icon_rsrcs, entries, idx)
     return Image.open(BytesIO(raw))
 
 

--- a/pe_file/pe_file.py
+++ b/pe_file/pe_file.py
@@ -294,23 +294,8 @@ class PEFile(ServiceBase):
                                 language_desc = 'Unknown language'
 
                             if entry_name == 'RT_GROUP_ICON':
-                                data_rva = language.data.struct.OffsetToData
-                                size = language.data.struct.Size
-                                data = self.pe_file.get_memory_mapped_image()[data_rva:data_rva+size]
-                                file_offset = self.pe_file.get_offset_from_rva(data_rva)
-
-                                grp_icon_dir = pefile.Structure(icon_extractor.GRPICONDIR_format, file_offset=file_offset)
-                                grp_icon_dir.__unpack__(data)
-
-                                if grp_icon_dir.Reserved == 0 or grp_icon_dir.Type == 1:
-                                    offset = grp_icon_dir.sizeof()
-                                    entries = list()
-                                    for idx in range(0, grp_icon_dir.Count):
-                                        grp_icon = pefile.Structure(icon_extractor.GRPICONDIRENTRY_format, file_offset=file_offset+offset)
-                                        grp_icon.__unpack__(data[offset:])
-                                        offset += grp_icon.sizeof()
-                                        entries.append(grp_icon)
-
+                                entries = icon_extractor.get_icon_group(self.pe_file, language.data.struct)
+                                if entries is not None:
                                     icon_groups.append(entries)
 
                             line = []

--- a/pe_file/pe_file.py
+++ b/pe_file/pe_file.py
@@ -320,6 +320,9 @@ class PEFile(ServiceBase):
                 for j in range(len(icon_groups)):
                     for i in range(len(icon_groups[j])):
                         icon_export = icon_extractor.icon_export(self.pe_file, icon_rsrcs, icon_groups[j], i)
+
+                        if icon_export is None: continue
+                        
                         name = 'RT_ICON_GROUP_' + str(j) + '_ICON_' + str(i) + '.ico'
                         path = os.path.join(self.working_directory, name)
                         icon_export.save(path)


### PR DESCRIPTION
This PR adds functionality to pull RT_ICON resources out of pe files as supplementary files. The .ico files are saved in the working directory. The bulk of the logic for extraction comes from [here](https://github.com/robomotic/pemeta/blob/master/extracticon.py), modified to mesh better with the pe service.