### PR TITLE
added thumbprint_md5 and thumbprint_sha256 fields for PEFile report needed client side

### DIFF
--- a/pe_file/pe_file.py
+++ b/pe_file/pe_file.py
@@ -836,9 +836,9 @@ class PEFile(ServiceBase):
                         signer_res.add_lines([f"Subject: {cert.subject.dn}",
                                               f"Valid From: {cert.valid_from.isoformat()}",
                                               f"Valid To: {cert.valid_to.isoformat()}",
-                                              f"Thumbprint: {hashlib.md5(cert.to_der).hexdigest()}",
-                                              f"Thumbprint: {hashlib.sha256(cert.to_der).hexdigest()}",
-                                              f"Thumbprint: {hashlib.sha1(cert.to_der).hexdigest()}"])
+                                              f"Thumbprint (MD5): {hashlib.md5(cert.to_der).hexdigest()}",
+                                              f"Thumbprint (SHA1): {hashlib.sha1(cert.to_der).hexdigest()}",
+                                              f"Thumbprint (SHA256): {hashlib.sha256(cert.to_der).hexdigest()}"])
 
                         signer_res.add_tag("cert.subject", cert.subject.dn)
                         signer_res.add_tag("cert.valid.start", cert.valid_from.isoformat())
@@ -856,9 +856,9 @@ class PEFile(ServiceBase):
                         # probably not worth doing tags for all this info?
                         cert_res.add_lines(["Version: %d" % cert.version,
                                             "Serial No: %d" % cert.serial_number,
-                                            "Thumbprint: %s" % hashlib.sha1(cert.to_der).hexdigest(),
-                                            "Thumbprint: %s" % hashlib.md5(cert.to_der).hexdigest(),
-                                            "Thumbprint: %s" % hashlib.sha256(cert.to_der).hexdigest(),
+                                            f"Thumbprint (MD5): {hashlib.md5(cert.to_der).hexdigest()}",
+                                            f"Thumbprint (SHA1): {hashlib.sha1(cert.to_der).hexdigest()}",
+                                            f"Thumbprint (SHA256): {hashlib.sha256(cert.to_der).hexdigest()}",
                                             "Issuer: %s" % cert.issuer.dn,
                                             "Subject: %s" % cert.subject.dn,
                                             "Valid From: %s" % cert.valid_from.isoformat(),


### PR DESCRIPTION
Added report fields for the md5 and sha256 hashes needed client side.

related to [PR](https://github.com/CybercentreCanada/assemblyline-base/pull/405)