### PR TITLE
add heuristic for extracted icons that aren't identified as images

### DIFF
--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -96,6 +96,12 @@ heuristics:
     name: Invalid Signature due to invalid Authenticode Signature version
     score: 500
 
+  - description: >-
+       The extracted RT_ICON from the PE wasn't identified as an image-type by the PIL library
+    filetype: "executable/windows"
+    heur_id: 11
+    name: Extracted RT_ICON is not an image
+    score: 100
 
 docker_config:
   image: ${REGISTRY}cccs/assemblyline-service-pefile:$SERVICE_TAG


### PR DESCRIPTION
Raise a heuristic for files that seem to be masquerading as resource icons and add these file as extracted for analysis.